### PR TITLE
Fix for usbmixd system user name

### DIFF
--- a/usbmuxd.sysusers
+++ b/usbmuxd.sysusers
@@ -1,1 +1,1 @@
-u usbmuxd - "usbmuxd user" /proc /sbin/nologin
+u usbmux - "usbmuxd user" /proc /sbin/nologin


### PR DESCRIPTION
Systemd's service and udev's rule wants 'usbmux' user, but 'usbmuxd' provided by usbmuxd.sysusesrs